### PR TITLE
refactor: Article 에러 핸들러 이름 변경

### DIFF
--- a/server/src/main/java/teamFive/freshmanCommunity/api/GlobalExceptionHandler.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/api/GlobalExceptionHandler.java
@@ -9,7 +9,7 @@ import teamFive.freshmanCommunity.exception.NonExistentBoardIdException;
 
 @RestControllerAdvice
 @Slf4j
-public class ArticleApiControllerAdvice {
+public class GlobalExceptionHandler {
     @ExceptionHandler(NonExistentBoardIdException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String nonExistentBoardIdExceptionHandler(NonExistentBoardIdException e) {

--- a/server/src/main/java/teamFive/freshmanCommunity/exception/BoardNotFoundException.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/exception/BoardNotFoundException.java
@@ -1,7 +1,7 @@
 package teamFive.freshmanCommunity.exception;
 
-public class NonExistentBoardIdException extends RuntimeException{
-    public NonExistentBoardIdException() {
+public class BoardNotFoundException extends RuntimeException{
+    public BoardNotFoundException() {
         super("존재하지 않는 게시판입니다.");
     }
 }

--- a/server/src/main/java/teamFive/freshmanCommunity/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package teamFive.freshmanCommunity.api;
+package teamFive.freshmanCommunity.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/server/src/main/java/teamFive/freshmanCommunity/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/exception/GlobalExceptionHandler.java
@@ -5,14 +5,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import teamFive.freshmanCommunity.exception.NonExistentBoardIdException;
 
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
-    @ExceptionHandler(NonExistentBoardIdException.class)
+    @ExceptionHandler(BoardNotFoundException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public String nonExistentBoardIdExceptionHandler(NonExistentBoardIdException e) {
+    public String nonExistentBoardIdExceptionHandler(BoardNotFoundException e) {
         log.error("{}", e.getMessage());
         return e.getMessage();
     }

--- a/server/src/main/java/teamFive/freshmanCommunity/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/exception/GlobalExceptionHandler.java
@@ -8,10 +8,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
-
-@ControllerAdvice
-public class GlobalExceptionHandler {
-
     @ExceptionHandler(DuplicateMemberException.class)
     public ResponseEntity<String> handleDuplicateMemberException(DuplicateMemberException e) {
         return ResponseEntity

--- a/server/src/main/java/teamFive/freshmanCommunity/service/ArticleService.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/service/ArticleService.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import teamFive.freshmanCommunity.dto.ArticleDto;
 import teamFive.freshmanCommunity.entity.Article;
-import teamFive.freshmanCommunity.exception.NonExistentBoardIdException;
+import teamFive.freshmanCommunity.exception.BoardNotFoundException;
 import teamFive.freshmanCommunity.repository.ArticleRepository;
 
 import java.util.ArrayList;
@@ -20,7 +20,7 @@ public class ArticleService {
     public List<ArticleDto> articles(Long majorId) {
         // 0.5. majorId 존재 안할 시 예외 처리 : 몇 번이 무슨 학과인지, 몇 번까지 있는지는 한 번 찾아봐야 할 것 같습니다.
         if (majorId <0 || majorId > 90) {
-            throw new NonExistentBoardIdException();
+            throw new BoardNotFoundException();
         }
         // 1. 게시글 조회
         List<Article> articles = articleRepository.findAllByMajor(majorId);


### PR DESCRIPTION
## 📚개요
Article 관련 에러를 처리하는 핸들러의 이름을 변경하였습니다.

## 💡Key Changes
ArticleApiControllerAdvice의 이름을 다른 핸들러와 같은 GlobalExceptionHandler로 변경하였습니다.

## ✅To Reviewers
머지할  때 문제될 점 없는지 확인해주세요!

## 🎓Reference
스프링 에러 처리 방법 관련 - https://mangkyu.tistory.com/204
ControllerAdvice를 여러 개 사용하기 위해서는 어노테이션을 추가하는 등 별도의 설정이 필요하여 되도록 하나의 프로젝트에서는 하나의 핸들러만을 사용하는 것을 권장한다는 내용이 있습니다.
