### PR TITLE
feat: 댓글 좋아요 로직 구현

### DIFF
--- a/server/src/main/java/teamFive/freshmanCommunity/api/LikeCommentApiController.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/api/LikeCommentApiController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import teamFive.freshmanCommunity.dto.LikeDto;
 import teamFive.freshmanCommunity.entity.LikeComment;
 import teamFive.freshmanCommunity.service.LikeCommentService;
 
@@ -18,11 +19,11 @@ public class LikeCommentApiController {
     private final LikeCommentService likeCommentService;
 
     @PostMapping("/comment/{commentId}/like")
-    public ResponseEntity<String> addLike(@PathVariable Long commentId, HttpServletRequest request) {
+    public ResponseEntity<LikeDto> addLike(@PathVariable Long commentId, HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        LikeCommentService.addLike(commentId, session);
-        return ResponseEntity.status(HttpStatus.OK).body("좋아요 처리 완료");
+        LikeDto like = likeCommentService.addLike(commentId, session);
+        return ResponseEntity.status(HttpStatus.OK).body(like);
     }
 
 }

--- a/server/src/main/java/teamFive/freshmanCommunity/api/LikeCommentApiController.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/api/LikeCommentApiController.java
@@ -21,7 +21,7 @@ public class LikeCommentApiController {
     public ResponseEntity<String> addLike(@PathVariable Long commentId, HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        LikeComment.addLike(commentId, session);
+        LikeCommentService.addLike(commentId, session);
         return ResponseEntity.status(HttpStatus.OK).body("좋아요 처리 완료");
     }
 

--- a/server/src/main/java/teamFive/freshmanCommunity/api/LikeCommentApiController.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/api/LikeCommentApiController.java
@@ -1,0 +1,28 @@
+package teamFive.freshmanCommunity.api;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import teamFive.freshmanCommunity.entity.LikeComment;
+import teamFive.freshmanCommunity.service.LikeCommentService;
+
+@RestController
+@RequiredArgsConstructor
+public class LikeCommentApiController {
+
+    private final LikeCommentService likeCommentService;
+
+    @PostMapping("/comment/{commentId}/like")
+    public ResponseEntity<String> addLike(@PathVariable Long commentId, HttpServletRequest request) {
+
+        HttpSession session = request.getSession();
+        LikeComment.addLike(commentId, session);
+        return ResponseEntity.status(HttpStatus.OK).body("좋아요 처리 완료");
+    }
+
+}

--- a/server/src/main/java/teamFive/freshmanCommunity/dto/LikeDto.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/dto/LikeDto.java
@@ -1,0 +1,21 @@
+package teamFive.freshmanCommunity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import teamFive.freshmanCommunity.entity.LikeComment;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LikeDto {
+    private String result;
+    private boolean status;
+
+    public static LikeDto createLikeDto(String result, LikeComment likeComment) {
+        return new LikeDto(
+                result,
+                likeComment.isStatus()
+        );
+    }
+}

--- a/server/src/main/java/teamFive/freshmanCommunity/dto/LikeDto.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/dto/LikeDto.java
@@ -9,12 +9,12 @@ import teamFive.freshmanCommunity.entity.LikeComment;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LikeDto {
-    private String result;
+    private String message;
     private boolean status;
 
-    public static LikeDto createLikeDto(String result, LikeComment likeComment) {
+    public static LikeDto createLikeDto(String message, LikeComment likeComment) {
         return new LikeDto(
-                result,
+                message,
                 likeComment.isStatus()
         );
     }

--- a/server/src/main/java/teamFive/freshmanCommunity/entity/Comment.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/entity/Comment.java
@@ -1,10 +1,7 @@
 package teamFive.freshmanCommunity.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import teamFive.freshmanCommunity.dto.CommentDto;
 
@@ -13,6 +10,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 @ToString
 @Entity
 public class Comment {

--- a/server/src/main/java/teamFive/freshmanCommunity/entity/LikeComment.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/entity/LikeComment.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @ToString
 @Entity
@@ -18,16 +19,27 @@ public class LikeComment {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name="member_id")
-    @OnDelete(action= OnDeleteAction.CASCADE) //멤버가 지워지면, likeComment 릴레이션도 삭제됨
+    @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE) //멤버가 지워지면, likeComment 릴레이션도 삭제됨
     private Member member;
 
     @ManyToOne
-    @JoinColumn(name="comment_id")
+    @JoinColumn(name = "comment_id")
     private Comment comment;
 
-    public Like(Member member, Comment comment){
-        this.member = member;
-        this.comment = comment;
+    @Column(nullable = false)
+    private boolean status;
+
+    public static LikeComment createLike(Member member, Comment comment) {
+        return new LikeComment(
+                null,
+                member,
+                comment,
+                true
+        );
+    }
+
+    public void deleteLike(Comment comment) {
+        this.status = false;
     }
 }

--- a/server/src/main/java/teamFive/freshmanCommunity/entity/LikeComment.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/entity/LikeComment.java
@@ -5,8 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
-@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @ToString
@@ -18,9 +19,15 @@ public class LikeComment {
 
     @ManyToOne
     @JoinColumn(name="member_id")
+    @OnDelete(action= OnDeleteAction.CASCADE) //멤버가 지워지면, likeComment 릴레이션도 삭제됨
     private Member member;
 
     @ManyToOne
     @JoinColumn(name="comment_id")
     private Comment comment;
+
+    public Like(Member member, Comment comment){
+        this.member = member;
+        this.comment = comment;
+    }
 }

--- a/server/src/main/java/teamFive/freshmanCommunity/entity/Major.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/entity/Major.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 public class Major {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "majorId")
+    @Column(name = "major_id")
     private Long id;
 
     @Column

--- a/server/src/main/java/teamFive/freshmanCommunity/entity/Member.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/entity/Member.java
@@ -33,7 +33,7 @@ public class Member {
 
     //학과 정보
     @ManyToOne
-    @JoinColumn(name = "majorId")
+    @JoinColumn(name = "major_id")
     private Major major;
 
 

--- a/server/src/main/java/teamFive/freshmanCommunity/entity/Member.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/entity/Member.java
@@ -15,7 +15,7 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "memberId")
+    @Column(name = "member_id")
     private Long id;
 
     @Column

--- a/server/src/main/java/teamFive/freshmanCommunity/repository/LikeCommentRepository.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/repository/LikeCommentRepository.java
@@ -1,0 +1,13 @@
+package teamFive.freshmanCommunity.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import teamFive.freshmanCommunity.entity.Comment;
+import teamFive.freshmanCommunity.entity.LikeComment;
+import teamFive.freshmanCommunity.entity.Member;
+
+public interface LikeCommentRepository extends JpaRepository<LikeComment, Long> {
+
+    LikeComment findByMemberAndComment(Member member, Comment comment);
+
+    void deleteByMemberAndComment(Member member, Comment comment);
+}

--- a/server/src/main/java/teamFive/freshmanCommunity/service/LikeCommentService.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/service/LikeCommentService.java
@@ -9,6 +9,7 @@ import teamFive.freshmanCommunity.entity.Comment;
 import teamFive.freshmanCommunity.entity.LikeComment;
 import teamFive.freshmanCommunity.entity.Member;
 import teamFive.freshmanCommunity.exception.CommentNotFoundException;
+import teamFive.freshmanCommunity.exception.MemberNotFoundException;
 import teamFive.freshmanCommunity.repository.CommentRepository;
 import teamFive.freshmanCommunity.repository.LikeCommentRepository;
 
@@ -25,6 +26,8 @@ public class LikeCommentService {
         Member member = (Member) session.getAttribute("member");
         Comment comment = commentRepository.findById(commentId).
                 orElseThrow(() -> new CommentNotFoundException());
+
+        if(member == null) throw new MemberNotFoundException("로그인하지 않은 상태에선 좋아요를 누를 수 없습니다.");
 
         if (likeCommentRepository.findByMemberAndComment(member, comment) == null) { //좋아요가 없으면
             comment.setLikesCount(comment.getLikesCount() + 1); //1씩 증가

--- a/server/src/main/java/teamFive/freshmanCommunity/service/LikeCommentService.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/service/LikeCommentService.java
@@ -1,0 +1,43 @@
+package teamFive.freshmanCommunity.service;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import teamFive.freshmanCommunity.dto.LikeDto;
+import teamFive.freshmanCommunity.entity.Comment;
+import teamFive.freshmanCommunity.entity.LikeComment;
+import teamFive.freshmanCommunity.entity.Member;
+import teamFive.freshmanCommunity.exception.CommentNotFoundException;
+import teamFive.freshmanCommunity.repository.CommentRepository;
+import teamFive.freshmanCommunity.repository.LikeCommentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class LikeCommentService {
+
+    private final CommentService commentService;
+    private final CommentRepository commentRepository;
+    private final LikeCommentRepository likeCommentRepository;
+
+    @Transactional
+    public LikeDto addLike(Long commentId, HttpSession session) {
+        Member member = (Member) session.getAttribute("member");
+        Comment comment = commentRepository.findById(commentId).
+                orElseThrow(() -> new CommentNotFoundException());
+
+        if (likeCommentRepository.findByMemberAndComment(member, comment) == null) { //좋아요가 없으면
+            comment.setLikesCount(comment.getLikesCount() + 1); //1씩 증가
+            LikeComment likeComment = LikeComment.createLike(member, comment); //true처리
+            likeCommentRepository.save(likeComment);
+            return LikeDto.createLikeDto("좋아요 처리 완료", likeComment);
+        }
+        else { //이미 좋아요 눌렀으면
+            comment.setLikesCount(comment.getLikesCount() - 1);
+            LikeComment likeComment = likeCommentRepository.findByMemberAndComment(member, comment);
+            likeComment.deleteLike(comment); //false처리
+            likeCommentRepository.deleteByMemberAndComment(member, comment);
+            return LikeDto.createLikeDto("좋아요 취소 완료", likeComment);
+        }
+    }
+}


### PR DESCRIPTION
## 📚개요
PR의 대략적인 내용을 적습니다.
-댓글 좋아요 로직 구현했습니다!

## 💡Key Changes
이전 코드와 비교했을 때 중요한 변화에 대해 설명합니다.
-댓글 좋아요 로직 구현하였고, 좋아요를 누르면 likesCount가 1씩 증가, 좋아요를 취소하면 likesCount가 1씩 감소하게 하였습니다.
-또한 댓글 좋아요 로직과는 관련이 없지만 멤버와 메이저의 컬럼명을 memberId -> member_id   /  majorId -> major_id 로 변경하였습니다.

## ✅To Reviewers
특히 리뷰할 때 신경 써주었으면 하는 점을 적습니다.
-저번에 말해주셨던 좋아요 누르면 색이 채워지고 취소하면 색 없어지는 기능을 위한 status가 likeComment에 들어가는 게 맞는 거 같아서 api response로 "좋아요 처리 완료" or "좋아요 취소 완료" 메시지와 true, false값을 반환하게 했는데 이 부분 맞는지 잘 봐주시면 감사하겠습니다!!

## 🎓Reference
참고한 문서나 자료의 링크를 첨부합니다.
