### PR TITLE
feat:게시글 작성이나 수정 시 article dto에 제목이나 내용이 공백일 경우 발생하는 예외 추가, 게시글 조회 시 majorId 판단 기준 변경

### DIFF
--- a/server/src/main/java/teamFive/freshmanCommunity/exception/ArticleMissingContentException.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/exception/ArticleMissingContentException.java
@@ -1,0 +1,7 @@
+package teamFive.freshmanCommunity.exception;
+
+public class ArticleMissingContentException extends RuntimeException {
+    public ArticleMissingContentException() {
+        super("게시글의 제목이나 내용이 빠져있습니다.");
+    }
+}

--- a/server/src/main/java/teamFive/freshmanCommunity/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
@@ -102,6 +101,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleMajorNotFoundException(MajorNotFoundException e) {
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
+                .body(e.getMessage());
+    }
+
+    @ExceptionHandler(ArticleMissingContentException.class)
+    public ResponseEntity<String> handleArticleMissingContentException(ArticleMissingContentException e) {
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
                 .body(e.getMessage());
     }
 }

--- a/server/src/main/java/teamFive/freshmanCommunity/service/ArticleService.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/service/ArticleService.java
@@ -39,6 +39,10 @@ public class ArticleService {
         HttpSession session = request.getSession();
         Member member = (Member) session.getAttribute("member");
         if (member == null) throw new MemberNotFoundException("멤버 조회 실패");
+        // dto에 제목이나 내용이 비어있을 시
+        if (dto.getContent().isBlank()|| dto.getTitle().isBlank()) {
+            throw new ArticleMissingContentException();
+        }
         // 2. 게시글 엔티티 생성
         Article article = Article.create(dto, major, member);
         // 3. 게시글 엔티티를 db에 저장
@@ -81,6 +85,10 @@ public class ArticleService {
         Member member = (Member) session.getAttribute("member");
         if (member == null) throw new MemberNotFoundException("멤버 조회 실패");
         if(!(target.getMember().getId().equals(member.getId()))) throw new ArticleUpdateAccessDeniedException();
+        // dto에 제목이나 내용이 비어있을 시
+        if (dto.getContent().isBlank()|| dto.getTitle().isBlank()) {
+            throw new ArticleMissingContentException();
+        }
         // 2. 게시글 수정
         target.patch(dto);
         // 3. DB로 갱신

--- a/server/src/main/java/teamFive/freshmanCommunity/service/ArticleService.java
+++ b/server/src/main/java/teamFive/freshmanCommunity/service/ArticleService.java
@@ -52,8 +52,8 @@ public class ArticleService {
     }
 
     public List<ArticleReadDto> articles(Long majorId) {
-        // 0.5. majorId 존재 안할 시 예외 처리 : 몇 번이 무슨 학과인지, 몇 번까지 있는지는 한 번 찾아봐야 할 것 같습니다.
-        if (majorId <0 || majorId > 90) {
+        // 0.5. majorId 존재 안할 시 예외 처리
+        if (!majorRepository.existsById(majorId)) {
             throw new BoardNotFoundException();
         }
         // 1. 게시글 조회


### PR DESCRIPTION
## 📚개요
게시글 작성, 수정 시 article dto에 공백이 포함되어 있을 경우 예외처리를 추가하였습니다.
그리고, majorId가 존재하지 않을 경우를 수정했습니다.

## 💡Key Changes
위와 같은 케이스를 처리하는 예외인 ArticleMissingContentException을 추가하고, 해당 예외를 throw하도록 articleService를 수정하였습니다.
그리고 majorId를 범위로 탐색하는 것이 아니라, majorRepository에서 검색하는 것으로 변경했습니다.

## ✅To Reviewers

## 🎓Reference
공백 판단 관련 : https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringUtils.html#isBlank-java.lang.CharSequence-
